### PR TITLE
Update app.go with IBC v2.0 changes to fix client-update proposal

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -89,6 +89,7 @@ import (
 	ibc "github.com/cosmos/ibc-go/v2/modules/core"
 	ibcclient "github.com/cosmos/ibc-go/v2/modules/core/02-client"
 	ibcclientclient "github.com/cosmos/ibc-go/v2/modules/core/02-client/client"
+        ibcclienttypes "github.com/cosmos/ibc-go/v2/modules/core/02-client/types"
 	porttypes "github.com/cosmos/ibc-go/v2/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
@@ -379,7 +380,7 @@ func NewEvmos(
 		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
 		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.DistrKeeper)).
 		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.UpgradeKeeper)).
-		AddRoute(ibchost.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
 		AddRoute(irt.RouterKey, intrarelayer.NewIntrarelayerProposalHandler(app.IntrarelayerKeeper))
 
 	govKeeper := govkeeper.NewKeeper(


### PR DESCRIPTION
Closes: actually we are not able to submit a client-update proposal, because it's in IBC v2.0 but we get "client: no handler exists for proposal type"

Description: The package IBC-GO v2.0 had been updated in past releases but there weren't in place the required modification for types and route described in that migration path article https://github.com/cosmos/ibc-go/blob/main/docs/migrations/sdk-to-v1.md#upgradeproposal
Necessary changes has been made