### PR TITLE
Unsafe-reset-all and reupdate script fixes

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -120,7 +120,7 @@ wget https://github.com/alpha-omega-labs/genesisd/raw/neolithic/genesis_29-1-sta
 cd
 
 # RESET TO IMPORTED genesis.json
-genesisd unsafe-reset-all
+genesisd tendermint unsafe-reset-all
 
 # ADD PEERS, ADJUST SETTINGS
 cd 

--- a/vendor/github.com/cosmos/cosmos-sdk/server/util.go
+++ b/vendor/github.com/cosmos/cosmos-sdk/server/util.go
@@ -279,7 +279,7 @@ func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator type
 
 	rootCmd.AddCommand(
 		startCmd,
-//	UnsafeResetAllCmd(),
+//		UnsafeResetAllCmd(),
 		tendermintCmd,
 		ExportCmd(appExport, defaultNodeHome),
 		version.NewVersionCommand(),

--- a/vendor/github.com/cosmos/cosmos-sdk/server/util.go
+++ b/vendor/github.com/cosmos/cosmos-sdk/server/util.go
@@ -279,7 +279,7 @@ func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator type
 
 	rootCmd.AddCommand(
 		startCmd,
-		// UnsafeResetAllCmd(),
+//	UnsafeResetAllCmd(),
 		tendermintCmd,
 		ExportCmd(appExport, defaultNodeHome),
 		version.NewVersionCommand(),

--- a/vendor/github.com/cosmos/cosmos-sdk/server/util.go
+++ b/vendor/github.com/cosmos/cosmos-sdk/server/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	tmcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	tmcfg "github.com/tendermint/tendermint/config"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -270,13 +271,15 @@ func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator type
 		ShowValidatorCmd(),
 		ShowAddressCmd(),
 		VersionCmd(),
+		tmcmd.ResetAllCmd,
+		tmcmd.ResetStateCmd,
 	)
 	startCmd := StartCmd(appCreator, defaultNodeHome)
 	addStartFlags(startCmd)
 
 	rootCmd.AddCommand(
 		startCmd,
-//		UnsafeResetAllCmd(),
+		// UnsafeResetAllCmd(),
 		tendermintCmd,
 		ExportCmd(appExport, defaultNodeHome),
 		version.NewVersionCommand(),

--- a/vendor/github.com/tharsis/ethermint/server/util.go
+++ b/vendor/github.com/tharsis/ethermint/server/util.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/version"
 
+	tmcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	rpcclient "github.com/tendermint/tendermint/rpc/jsonrpc/client"
 )
@@ -28,6 +29,8 @@ func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator type
 		sdkserver.ShowValidatorCmd(),
 		sdkserver.ShowAddressCmd(),
 		sdkserver.VersionCmd(),
+		tmcmd.ResetAllCmd,
+		tmcmd.ResetStateCmd,
 	)
 
 	startCmd := StartCmd(appCreator, defaultNodeHome)


### PR DESCRIPTION
Hey,

So there were 3 things:
1) echo "* - nofile 50000" >> /etc/security/limits.confnesis_29-2 -> a small typo error, copy-paste error I think.
2) I added a for loop to check all .genesisd_backup* folders and find the oldest based on `stat -c %Y`, this is afterwards used to copy the keys from. I didn't add the .evmos_backup alternative, but if you want that one added as well in the logic, tell me before merging this PR.
3) Unsafe-reset-all didn't work in this repo, neither did `genesisd unsafe-reset-all` work or `genesisd tendermint unsafe-reset-all`. I looked in the code and everything based on unsafe-reset-all was commented out. I therefore went and looked where the unsafe-reset-all command was moved to the tendermint sub-command section and found this PR for it in the cosmos-sdk repository: https://github.com/cosmos/cosmos-sdk/pull/11562/files#diff-f7a5b3de7e2284cfc3a3deca80a48a336566e6bc0b682a90156e691d876f38a2